### PR TITLE
Abstract Data Fetching From Wikipedia API

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -96,7 +96,7 @@
 import { mapState, mapMutations } from "vuex";
 
 import { mdiMagnify, mdiArrowLeft, mdiFileDocumentBox } from "@mdi/js";
-import axios from "axios";
+import generalApi from "../wiki/api/general";
 
 export default {
   name: "Search",
@@ -137,8 +137,6 @@ export default {
       }
     },
     wikiSearch: async function(value) {
-      const titleQuery = value.trim();
-      const api = `https://${this.contentLanguage}.wikipedia.org/w/api.php?action=query&generator=prefixsearch&gpssearch=${titleQuery}&prop=pageimages|description&piprop=thumbnail&pithumbsize=50&pilimit=10&format=json&formatversion=2&origin=*`;
       // Handle empty value
       if (!value) {
         this.articles = [];
@@ -149,11 +147,8 @@ export default {
         return;
       }
       this.isLoading = true;
-      this.articles = await axios
-        .get(api)
-        .then(response => {
-          return response.data.query.pages;
-        })
+      this.articles = await generalApi
+        .wikiSearch(this.contentLanguage, value)
         .finally(() => (this.isLoading = false));
     },
     ...mapMutations(["setContentLanguage"])

--- a/src/plugins/editor/index.js
+++ b/src/plugins/editor/index.js
@@ -24,7 +24,6 @@ import Underline from "./marks/Underline";
 
 import History from "./extensions/History";
 
-import axios from "axios";
 class WikiEditor extends Editor {
   constructor(options) {
     const defaultOptions = {
@@ -55,12 +54,6 @@ class WikiEditor extends Editor {
       ]
     };
     super(Object.assign(options, defaultOptions));
-  }
-  html2wikitext(html) {
-    const api = `https://${this.contentLanguage}.wikipedia.org/api/rest_v1/transform/html/to/wikitext`;
-    return axios
-      .post(api, { html, scrub_wikitext: true })
-      .then(response => response.data);
   }
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -84,8 +84,8 @@
 </template>
 
 <script>
-import axios from "axios";
 import { mapState } from "vuex";
+import generalApi from "../wiki/api/general";
 
 export default {
   name: "Home",
@@ -108,14 +108,9 @@ export default {
   },
   methods: {
     feed() {
-      const today = new Date();
-      const year = today.getFullYear();
-      const month = ("0" + (today.getMonth() + 1)).slice(-2);
-      const date = ("0" + today.getDate()).slice(-2);
-      const api = `https://${this.contentLanguage}.wikipedia.org/api/rest_v1/feed/featured/${year}/${month}/${date}`;
-      axios.get(api).then(response => {
-        this.mostreadArticles = response.data.mostread.articles;
-        this.tfa = response.data.tfa;
+      generalApi.fetchFeed(this.contentLanguage).then(feed => {
+        this.mostreadArticles = feed.mostread.articles;
+        this.tfa = feed.tfa;
       });
     }
   }

--- a/src/wiki/api/general.js
+++ b/src/wiki/api/general.js
@@ -17,7 +17,15 @@ function wikiSearch(language, query) {
   return axios.get(api).then(response => response.data.query.pages);
 }
 
+function html2wikitext(language, html) {
+  const api = `https://${language}.wikipedia.org/api/rest_v1/transform/html/to/wikitext`;
+  return axios
+    .post(api, { html, scrub_wikitext: true })
+    .then(response => response.data);
+}
+
 export default {
   fetchFeed,
-  wikiSearch
+  wikiSearch,
+  html2wikitext
 };

--- a/src/wiki/api/general.js
+++ b/src/wiki/api/general.js
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+function fetchFeed(language) {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = ("0" + (today.getMonth() + 1)).slice(-2);
+  const date = ("0" + today.getDate()).slice(-2);
+
+  const api = `https://${language}.wikipedia.org/api/rest_v1/feed/featured/${year}/${month}/${date}`;
+  return axios.get(api).then(response => response.data);
+}
+
+function wikiSearch(language, query) {
+  const titleQuery = query.trim();
+  const api = `https://${language}.wikipedia.org/w/api.php?action=query&generator=prefixsearch&gpssearch=${titleQuery}&prop=pageimages|description&piprop=thumbnail&pithumbsize=50&pilimit=10&format=json&formatversion=2&origin=*`;
+
+  return axios.get(api).then(response => response.data.query.pages);
+}
+
+export default {
+  fetchFeed,
+  wikiSearch
+};


### PR DESCRIPTION
This separates remaining Wikipedia HTTP API calls to a general API file. This abstraction helps to easily modify wikivue to use other means to fetch from Wikipedia (dweb), like replacing axios.