### PR TITLE
Autofocus searchbox after clicking on it

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -35,6 +35,7 @@
           :placeholder="$i18n('header-search')"
           :prepend-inner-icon="mdiMagnify"
           class="article-search"
+          autofocus
         >
         </v-text-field>
         <v-spacer v-if="$vuetify.breakpoint.lgAndUp" />


### PR DESCRIPTION
Currently after clicking the searchbox, the input is not focused which is annoying. This fixes it.